### PR TITLE
fix bug that can not figure out current machine IP

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -83,7 +83,7 @@ if [ -d ${cfg_root_dir} ]; then
 fi
 
 # grab the IP address of this machine
-this_machine=`ip addr | grep inet | grep -v inet6 | grep -E "global (dynamic)+ ens" | awk '{print $2}' |awk -F "/" '{print $1}'`
+this_machine=`ip addr | grep inet | grep -v inet6 | grep -E "global( dynamic)? ens[0-9]*" | awk '{print $2}' |awk -F "/" '{print $1}'`
 # echo "this_machine: ${this_machine}"
 if [ ! -n "${this_machine}" ]; then
     echo -e "\033[1;30m Failed to get current machind IP \033[0m"


### PR DESCRIPTION
if the result of comman 'ip addr' is 'inet 192.168.0.107/24 brd 192.168.0.255 scope global ens160',
instead of 'inet 192.168.0.107/24 brd 192.168.0.255 scope global dynamic ens160'